### PR TITLE
Fix some errors in FilterNode functionality

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Release 3.6.0
  
 * fix too specific params of *build.bat* #16, by @flipback
 * fix OpenSSL-1.1 compatibility in test compilation #46, by @flipback
+* fix type conversion of refernces on the same value #67, by @flipback
+* fix comparison in *OpcUaStackCore::ComparisonFilterNode* #67, by @flipback
 
 **Documentation**:
 

--- a/src/OpcUaStackCore/BuildInTypes/OpcUaTypeConversion.cpp
+++ b/src/OpcUaStackCore/BuildInTypes/OpcUaTypeConversion.cpp
@@ -92,7 +92,10 @@ namespace OpcUaStackCore
 		{
 		case '-':
 		{
-			targetVariant.copyFrom(sourceVariant);
+			if (&sourceVariant != &targetVariant) {
+				targetVariant.copyFrom(sourceVariant);
+			}
+
 			return true;
 		}
 		case 'I':

--- a/src/OpcUaStackCore/BuildInTypes/OpcUaTypeConversion.cpp
+++ b/src/OpcUaStackCore/BuildInTypes/OpcUaTypeConversion.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2017 Kai Huebl (kai@huebl-sgh.de)
+   Copyright 2017-2018 Kai Huebl (kai@huebl-sgh.de)
 
    Lizenziert gemäß Apache Licence Version 2.0 (die „Lizenz“); Nutzung dieser
    Datei nur in Übereinstimmung mit der Lizenz erlaubt.
@@ -19,13 +19,6 @@
 
 namespace OpcUaStackCore
 {
-
-	//operator bool(const std::string& value) const
-	//{
-	//	return true;
-	//}
-
-
 
 	OpcUaTypeConversion::OpcUaTypeConversion(void)
 	{

--- a/src/OpcUaStackCore/Filter/ComparisonFilterNode.cpp
+++ b/src/OpcUaStackCore/Filter/ComparisonFilterNode.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2017 Kai Huebl (kai@huebl-sgh.de)
+   Copyright 2017-2018 Kai Huebl (kai@huebl-sgh.de)
 
    Lizenziert gemäß Apache Licence Version 2.0 (die „Lizenz“); Nutzung dieser
    Datei nur in Übereinstimmung mit der Lizenz erlaubt.

--- a/src/OpcUaStackCore/Filter/ComparisonFilterNode.cpp
+++ b/src/OpcUaStackCore/Filter/ComparisonFilterNode.cpp
@@ -82,21 +82,24 @@ namespace OpcUaStackCore
             	return false;
             }
 
-    		OpcUaTypeConversion converter;
-    		// Convert variable with greater precedence rank
-    		if (converter.precedenceRank(value1.variantType()) < converter.precedenceRank(value2.variantType())) {
-    			std::swap(value1, value2);
-    		}
-    	    char conveType = converter.conversionType(value1.variantType(), value2.variantType());
+            bool converted = true;
 
-    	    if (converter.conversion(value1, value2.variantType(), value1)) {
-				return compare(value1, value2, value);
-			} else {
-				value.set<OpcUaBoolean>(false); // see the description in table 115 of part 4
-			}
+            OpcUaTypeConversion converter;
+            // Convert variable with greater precedence rank
+            if (converter.precedenceRank(value1.variantType()) > converter.precedenceRank(value2.variantType())) {
+                converted = converter.conversion(value1, value2.variantType(), value1);
+            } else if (converter.precedenceRank(value1.variantType()) < converter.precedenceRank(value2.variantType())) {
+                converted = converter.conversion(value2, value1.variantType(), value2);
+            }
 
-			return true;
-		}
+            if (converted) {
+                return compare(value1, value2, value);
+            } else {
+                value.set<OpcUaBoolean>(false); // see the description in table 115 of part 4
+            }
+
+            return true;
+        }
 
 		return false;
     }

--- a/tst/OpcUaStackCore/BuildInTypes/OpcUaTypeConversion_t.cpp
+++ b/tst/OpcUaStackCore/BuildInTypes/OpcUaTypeConversion_t.cpp
@@ -1060,5 +1060,14 @@ BOOST_AUTO_TEST_CASE(OpcUaTypeConversion_XmlElement)
 	// SHOULD_BE_SAME_PTR			(OpcUaXmlElement, xmlElement);
 }
 
+BOOST_AUTO_TEST_CASE(OpcUaTypeConversion_ConvertTheSameData)
+{
+    OpcUaTypeConversion converter;
+    OpcUaVariant value1;
+    value1.set<OpcUaDouble>(0);
+
+    BOOST_REQUIRE(converter.conversion(value1, OpcUaBuildInType_OpcUaDouble, value1));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/tst/OpcUaStackCore/Filter/ComparisonFilterNode_t.cpp
+++ b/tst/OpcUaStackCore/Filter/ComparisonFilterNode_t.cpp
@@ -175,6 +175,30 @@ BOOST_AUTO_TEST_CASE(ComparisonFilterNode_120_less_than_or_eaual_100)
     BOOST_REQUIRE(operatorResult.get<OpcUaBoolean>() == false);
 }
 
+BOOST_AUTO_TEST_CASE(ComparisonFilterNode_120I_less_than_or_eaual_100F)
+{
+    std::vector<FilterNode::SPtr> args;
+    MAKE_TWO_LITERAL_ARGS(args, OpcUaInt32(120), OpcUaDouble(100));
+
+    ComparisonFilterNode lessThanOrEqualOperator(OpcUaOperator::LessThanOrEqual, args);
+
+    OpcUaVariant operatorResult;
+    BOOST_REQUIRE(lessThanOrEqualOperator.evaluate(operatorResult));
+    BOOST_REQUIRE(operatorResult.get<OpcUaBoolean>() == false);
+}
+
+BOOST_AUTO_TEST_CASE(ComparisonFilterNode_120F_less_than_or_eaual_100I)
+{
+    std::vector<FilterNode::SPtr> args;
+    MAKE_TWO_LITERAL_ARGS(args, OpcUaDouble(120), OpcUaInt32(100));
+
+    ComparisonFilterNode lessThanOrEqualOperator(OpcUaOperator::LessThanOrEqual, args);
+
+    OpcUaVariant operatorResult;
+    BOOST_REQUIRE(lessThanOrEqualOperator.evaluate(operatorResult));
+    BOOST_REQUIRE(operatorResult.get<OpcUaBoolean>() == false);
+}
+
 //------------------------------------------------
 // Handle errors
 //------------------------------------------------


### PR DESCRIPTION
The following bugs were fixed:
1. Fix crashing when two operand are referencing on the same value
2. Fix comparison operator node