### PR TITLE
Fix dependence of items monitoring on its callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build_*
 pki
 test.xml
 tst/data/opc.ua.roby_save.xml
+.idea

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Release 3.7.1
 
 **Bugs**:
 
+* fix dependence of start\\stop item monitoring on callbacks #133, by @flipback
+
 **Documentation**:
 
 

--- a/src/OpcUaStackServer/ServiceSet/MonitorManager.cpp
+++ b/src/OpcUaStackServer/ServiceSet/MonitorManager.cpp
@@ -513,13 +513,8 @@ namespace OpcUaStackServer
 		uint32_t monitoredItemId
 	)
 	{
-		ForwardNodeSync::SPtr forwardNodeSync = baseNodeClass->forwardNodeSync();
-		if (forwardNodeSync.get() == nullptr) return;
-		if (!forwardNodeSync->monitoredItemStartService().isCallback()) return;
-
 		// find node id in item id map
-		MonitoredItemIds::iterator it;
-		it = monitoredItemIds_.find(baseNodeClass->nodeId().data());
+		auto it = monitoredItemIds_.find(baseNodeClass->nodeId().data());
 		if (it != monitoredItemIds_.end()) {
 			// not the first monitored item
 
@@ -541,15 +536,19 @@ namespace OpcUaStackServer
 		nodeReference->statusCode(Success);
 		nodeReference->baseNodeClass(baseNodeClass);
 
-		// forward monitored item start
-		ApplicationMonitoredItemStartContext context;
-		context.nodeId_ = baseNodeClass->nodeId().data();
-		context.applicationContext_ = forwardNodeSync->monitoredItemStartService().applicationContext();
-		context.firstMonitoredItem_ = true;
-		context.nodeReference_ = nodeReference;
-		context.userContext_ = userContext;
 
-		forwardNodeSync->monitoredItemStartService().callback()(&context);
+        ForwardNodeSync::SPtr forwardNodeSync = baseNodeClass->forwardNodeSync();
+        if (forwardNodeSync && forwardNodeSync->monitoredItemStartService().isCallback()) {
+            // forward monitored item start
+            ApplicationMonitoredItemStartContext context;
+            context.nodeId_ = baseNodeClass->nodeId().data();
+            context.applicationContext_ = forwardNodeSync->monitoredItemStartService().applicationContext();
+            context.firstMonitoredItem_ = true;
+            context.nodeReference_ = nodeReference;
+            context.userContext_ = userContext;
+
+            forwardNodeSync->monitoredItemStartService().callback()(&context);
+        }
 	}
 
 	void
@@ -559,13 +558,8 @@ namespace OpcUaStackServer
 		uint32_t monitoredItemId
 	)
 	{
-		ForwardNodeSync::SPtr forwardNodeSync = baseNodeClass->forwardNodeSync();
-		if (forwardNodeSync.get() == nullptr) return;
-		if (!forwardNodeSync->monitoredItemStopService().isCallback()) return;
-
 		// find node id in item id map
-		MonitoredItemIds::iterator it1;
-		it1 = monitoredItemIds_.find(baseNodeClass->nodeId().data());
+		auto it1 = monitoredItemIds_.find(baseNodeClass->nodeId().data());
 		if (it1 == monitoredItemIds_.end()) {
 			// no monitored item exist
 			return;
@@ -593,15 +587,18 @@ namespace OpcUaStackServer
 		nodeReference->statusCode(Success);
 		nodeReference->baseNodeClass(baseNodeClass);
 
-		// forward monitored item stop
-		ApplicationMonitoredItemStopContext context;
-		context.nodeId_ = baseNodeClass->nodeId().data();
-		context.applicationContext_ = forwardNodeSync->monitoredItemStopService().applicationContext();
-		context.lastMonitoredItem_ = true;
-		context.nodeReference_ = nodeReference;
-		context.userContext_ = userContext;
+        ForwardNodeSync::SPtr forwardNodeSync = baseNodeClass->forwardNodeSync();
+        if (forwardNodeSync && forwardNodeSync->monitoredItemStopService().isCallback()) {
+            // forward monitored item stop
+            ApplicationMonitoredItemStopContext context;
+            context.nodeId_ = baseNodeClass->nodeId().data();
+            context.applicationContext_ = forwardNodeSync->monitoredItemStopService().applicationContext();
+            context.lastMonitoredItem_ = true;
+            context.nodeReference_ = nodeReference;
+            context.userContext_ = userContext;
 
-		forwardNodeSync->monitoredItemStopService().callback()(&context);
+            forwardNodeSync->monitoredItemStopService().callback()(&context);
+        }
 	}
 
 	// ------------------------------------------------------------------------
@@ -643,6 +640,12 @@ namespace OpcUaStackServer
 		forwardGlobalSync_->autorizationService().callback()(&context);
 
 		return context.statusCode_;
+	}
+
+    MonitorManager::MonitoredItemIdVector
+	MonitorManager::monitoredItemIds()
+	{
+        return monitoredItemIds_;
 	}
 
 }

--- a/src/OpcUaStackServer/ServiceSet/MonitorManager.h
+++ b/src/OpcUaStackServer/ServiceSet/MonitorManager.h
@@ -38,7 +38,7 @@ namespace OpcUaStackServer
 	class MonitorManager
 	{
 	  public:
-		typedef std::map<OpcUaNodeId,std::vector<uint32_t> > MonitoredItemIds;
+		using MonitoredItemIdVector = std::map<OpcUaNodeId,std::vector<uint32_t> >;
 
 		MonitorManager(void);
 		~MonitorManager(void);
@@ -50,6 +50,8 @@ namespace OpcUaStackServer
 		void forwardGlobalSync(ForwardGlobalSync::SPtr& forwardGlobalSync);
 		uint32_t noticicationNumber(void);
 		bool notificationAvailable(void);
+
+        MonitoredItemIdVector monitoredItemIds();
 
 
 		OpcUaStatusCode receive(ServiceTransactionCreateMonitoredItems::SPtr trx);
@@ -95,7 +97,7 @@ namespace OpcUaStackServer
 		InformationModel::SPtr informationModel_;
 		ForwardGlobalSync::SPtr forwardGlobalSync_;
 
-		MonitoredItemIds monitoredItemIds_;
+        MonitoredItemIdVector monitoredItemIds_;
 	};
 
 }

--- a/tst/OpcUaStackServer/AddressSpaceModel/RefernceItemMap_t.cpp
+++ b/tst/OpcUaStackServer/AddressSpaceModel/RefernceItemMap_t.cpp
@@ -6,8 +6,8 @@ using namespace OpcUaStackCore;
 using namespace OpcUaStackServer;
 
 
-struct F {
-    F() : map(), refId1(0), refId2(1), refId3(2), refId4(3)
+struct InitMap {
+    InitMap() : map(), refId1(0), refId2(1), refId3(2), refId4(3)
     {
 
     	map.add(ReferenceType::ReferenceType_Organizes, true, refId1);
@@ -17,7 +17,7 @@ struct F {
     	map.add(ReferenceType::ReferenceType_HasComponent, true, refId4);
     }
 
-    ~F() { }
+    ~InitMap() { }
 
     ReferenceItemMap map;
 	OpcUaNodeId refId1;
@@ -27,7 +27,7 @@ struct F {
 };
 
 
-BOOST_FIXTURE_TEST_SUITE(RefernceItemMap_, F)
+BOOST_FIXTURE_TEST_SUITE(RefernceItemMap_, InitMap)
 
 BOOST_AUTO_TEST_CASE(RefernceItemMap_)
 {

--- a/tst/OpcUaStackServer/ServiceSet/MonitorManager_t.cpp
+++ b/tst/OpcUaStackServer/ServiceSet/MonitorManager_t.cpp
@@ -23,13 +23,13 @@ struct InitMonitorManager {
 		ioThread->slotTimer(constructSPtr<SlotTimer>());
 		mm.ioThread(ioThread.get());
 
-		auto nodeToMonitor = constructSPtr<VariableNodeClass>();
+		nodeToMonitor = constructSPtr<VariableNodeClass>();
 		OpcUaNodeId nodeToMonitorId(0, 0);
 		nodeToMonitor->setNodeId(nodeToMonitorId);
 		OpcUaDataValue value(0);
 		nodeToMonitor->setValue(value);
 
-		auto sync = constructSPtr<ForwardNodeSync>();
+		sync = constructSPtr<ForwardNodeSync>();
 		auto startMonitoredItemCallback = Callback(boost::bind(&InitMonitorManager::startMonitored, this, _1));
 		auto stopMonitoredItemCallback = Callback(boost::bind(&InitMonitorManager::stopMonitored, this, _1));
 		sync->monitoredItemStartService().setCallback(startMonitoredItemCallback);
@@ -85,6 +85,8 @@ struct InitMonitorManager {
 	MonitorManager mm;
 	InformationModel::SPtr informationModel;
 	IOThread::SPtr ioThread;
+    ForwardNodeSync::SPtr sync;
+    VariableNodeClass::SPtr nodeToMonitor;
 
 	ServiceTransactionCreateMonitoredItems::SPtr createMonitoredItemTransaction;
 
@@ -163,6 +165,47 @@ BOOST_AUTO_TEST_CASE(MonitorManager_CallStopMonitoredItemCallbackOnlyOnce)
 	BOOST_REQUIRE_EQUAL(1, stopMonitoredItemCallCount);
 }
 
+BOOST_AUTO_TEST_CASE(MonitorManager_StartMonitoredItemWithoutCallback)
+{
+    sync->monitoredItemStartService().unsetCallback();
+    BOOST_REQUIRE_EQUAL(OpcUaStatusCode::Success, mm.receive(createMonitoredItemTransaction));
+
+    MonitoredItemCreateResult::SPtr result;
+    createMonitoredItemTransaction->response()->results()->get(0, result);
+
+    BOOST_REQUIRE_EQUAL(OpcUaStatusCode::Success, result->statusCode());
+    BOOST_REQUIRE_EQUAL(1, mm.monitoredItemIds().size());
+}
+
+BOOST_AUTO_TEST_CASE(MonitorManager_StopMonitoredItemWithoutCallback)
+{
+    BOOST_REQUIRE_EQUAL(OpcUaStatusCode::Success, mm.receive(createMonitoredItemTransaction));
+
+    auto deleteMonitoredItemTransaction =
+            makeDeleteMonitredItemTransaction(createMonitoredItemTransaction->response());
+
+    sync->monitoredItemStopService().unsetCallback();
+    BOOST_REQUIRE_EQUAL(OpcUaStatusCode::Success, mm.receive(deleteMonitoredItemTransaction));
+
+    OpcUaStatusCode status;
+    deleteMonitoredItemTransaction->response()->results()->get(0, status);
+
+    BOOST_REQUIRE_EQUAL(OpcUaStatusCode::Success, status);
+    BOOST_REQUIRE_EQUAL(0, mm.monitoredItemIds().size());
+}
+
+BOOST_AUTO_TEST_CASE(MonitorManager_StartStopMonitoringWithoutSync)
+{
+    nodeToMonitor->forwardNodeSync(nullptr);
+    BOOST_REQUIRE_EQUAL(OpcUaStatusCode::Success, mm.receive(createMonitoredItemTransaction));
+    BOOST_REQUIRE_EQUAL(1, mm.monitoredItemIds().size());
+
+    auto deleteMonitoredItemTransaction =
+            makeDeleteMonitredItemTransaction(createMonitoredItemTransaction->response());
+
+    BOOST_REQUIRE_EQUAL(OpcUaStatusCode::Success, mm.receive(deleteMonitoredItemTransaction));
+    BOOST_REQUIRE_EQUAL(0, mm.monitoredItemIds().size());
+}
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/tst/OpcUaStackServer/ServiceSet/MonitorManager_t.cpp
+++ b/tst/OpcUaStackServer/ServiceSet/MonitorManager_t.cpp
@@ -8,8 +8,8 @@
 using namespace OpcUaStackServer;
 
 
-struct F {
-    F() : mm()
+struct InitMonitorManager {
+    InitMonitorManager() : mm()
     , informationModel(constructSPtr<InformationModel>())
     , ioThread(constructSPtr<IOThread>())
     , createMonitoredItemTransaction(constructSPtr<ServiceTransactionCreateMonitoredItems>())
@@ -30,8 +30,8 @@ struct F {
 		nodeToMonitor->setValue(value);
 
 		auto sync = constructSPtr<ForwardNodeSync>();
-		auto startMonitoredItemCallback = Callback(boost::bind(&F::startMonitored, this, _1));
-		auto stopMonitoredItemCallback = Callback(boost::bind(&F::stopMonitored, this, _1));
+		auto startMonitoredItemCallback = Callback(boost::bind(&InitMonitorManager::startMonitored, this, _1));
+		auto stopMonitoredItemCallback = Callback(boost::bind(&InitMonitorManager::stopMonitored, this, _1));
 		sync->monitoredItemStartService().setCallback(startMonitoredItemCallback);
 		sync->monitoredItemStopService().setCallback(stopMonitoredItemCallback);
 
@@ -80,7 +80,7 @@ struct F {
 		return deleteMonitoredItemTransaction;
 	}
 
-    ~F() { }
+    ~InitMonitorManager() { }
 
 	MonitorManager mm;
 	InformationModel::SPtr informationModel;
@@ -94,7 +94,7 @@ struct F {
 };
 
 
-BOOST_FIXTURE_TEST_SUITE(MonitorManager_, F)
+BOOST_FIXTURE_TEST_SUITE(MonitorManager_, InitMonitorManager)
 
 BOOST_AUTO_TEST_CASE(MonitorManager_)
 {


### PR DESCRIPTION
Closes #133

* **Please check if the PR fulfills these requirements**
- [ x ] The commit message follows our guidelines
- [ x ] Tests for the changes have been added 
- [ x ] CHANGELOG have been updated 


* **What kind of change does this PR introduce?** 

Fix a bug in  MonitorManager

* **What is the current behavior?** (You can also link to an open issue here)

If a user doesn't set callbacks for start\\stop monitoring events, MonitorManager can't registers\\unrigesters them properly.

* **What is the new behavior (if this is a feature change)?**

MonitorManger registers\\unregisters the items independently if there are the calbacks or not. 

