### PR TITLE
Fix conflict DiscoveryServer URL and application EndpointURL

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Release 3.8.1
 **Bugs**:
 
 * fix libssl-dev dependency for dev DEB package #314, by @flipback
+* fix conflict of URLs discovery server and application endpoint #310, by @flipback
 
 Release 3.8.0 (2019-10-14)
 ------------------------------------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Release 3.8.1
 **Bugs**:
 
 * fix libssl-dev dependency for dev DEB package #314, by @flipback
-* fix conflict of URLs discovery server and application endpoint #310, by @flipback
+* fix defaul endpoint URL #310, by @flipback
 
 Release 3.8.0 (2019-10-14)
 ------------------------------------------------------------

--- a/src/OpcUaProjectBuilder/ProjectTemplate/src/ProjectName/Config/OpcUaServer.xml
+++ b/src/OpcUaProjectBuilder/ProjectTemplate/src/ProjectName/Config/OpcUaServer.xml
@@ -32,18 +32,18 @@
     
   </Logging>
   
-  <DiscoveryServer>
-    <DiscoveryUrl>opc.tcp://0.0.0.0:4840</DiscoveryUrl>
-    <RegisterInterval>40000</RegisterInterval>
-  </DiscoveryServer>
+<!--  <DiscoveryServer>-->
+<!--    <DiscoveryUrl>opc.tcp://127.0.0.1:4840</DiscoveryUrl>-->
+<!--    <RegisterInterval>40000</RegisterInterval>-->
+<!--  </DiscoveryServer>-->
    
   <Endpoints>
     <EndpointDescription>
-	  <EndpointUrl>opc.tcp://0.0.0.0:ProjectPort</EndpointUrl>
-	  <ApplicationUri>urn:0.0.0.0:ASNeG:ProjectName</ApplicationUri>
+	  <EndpointUrl>opc.tcp://@HOSTNAME@:ProjectPort</EndpointUrl>
+	  <ApplicationUri>urn:@HOSTNAME@:ASNeG:ProjectName</ApplicationUri>
 	  <ProductUri>urn:ASNeG:ProjectName</ProductUri>
 	  <ApplicationName>ProjectName</ApplicationName>
-	  <DiscoveryUrl>opc.tcp://0.0.0.0:ProjectPort</DiscoveryUrl>	
+	  <DiscoveryUrl>opc.tcp://@HOSTNAME@:ProjectPort</DiscoveryUrl>
 	  <GatewayServerUri></GatewayServerUri>
 	  <!-- <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#None</SecurityPolicyUri> -->
 	  
@@ -122,7 +122,7 @@
         <YearsValidFor>5</YearsValidFor>
         <KeyLength>2048</KeyLength>
         <CertificateType>RsaSha256</CertificateType>
-        <IPAddress>0.0.0.0</IPAddress>
+        <IPAddress>@HOSTNAME@</IPAddress>
         <DNSName>ASNeG.de</DNSName>
         <EMail>info@ASNeG.de</EMail>
       </CertificateSettings>

--- a/src/OpcUaServer/Server/DiscoveryClient.cpp
+++ b/src/OpcUaServer/Server/DiscoveryClient.cpp
@@ -68,21 +68,6 @@ namespace OpcUaServer
 			return false;
 		}
 
-		// check if the DiscoveryUrl matches EndPointUrls
-		boost::optional<Config> endPointsConfig = config.getChild("OpcUaServer.Endpoints");
-		std::vector<Config> endPointsConfigVec;
-		endPointsConfig->getChilds("EndpointDescription", endPointsConfigVec);
-		for (auto &endPoint : endPointsConfigVec) {
-			auto endPointUrl = endPoint.getChild("EndpointUrl")->getValue();
-			if (endPointUrl == discoveryServerUrl_) {
-				Log(Error, "endpoint URL of DiscoveryServer cannot equal the application's endpoint URL")
-					.parameter("DiscoveryServerUrl", discoveryServerUrl_)
-					.parameter("Application EndPointUrl", endPointUrl);
-
-				return false;
-			}
-		}
-
 		// get element register interval url
 		dicoveryServerConfig->getConfigParameter("RegisterInterval", registerInterval_, "40000");
 

--- a/src/OpcUaServer/Server/DiscoveryClient.cpp
+++ b/src/OpcUaServer/Server/DiscoveryClient.cpp
@@ -68,6 +68,21 @@ namespace OpcUaServer
 			return false;
 		}
 
+		// check if the DiscoveryUrl matches EndPointUrls
+		boost::optional<Config> endPointsConfig = config.getChild("OpcUaServer.Endpoints");
+		std::vector<Config> endPointsConfigVec;
+		endPointsConfig->getChilds("EndpointDescription", endPointsConfigVec);
+		for (auto &endPoint : endPointsConfigVec) {
+			auto endPointUrl = endPoint.getChild("EndpointUrl")->getValue();
+			if (endPointUrl == discoveryServerUrl_) {
+				Log(Error, "endpoint URL of DiscoveryServer cannot equal the application's endpoint URL")
+					.parameter("DiscoveryServerUrl", discoveryServerUrl_)
+					.parameter("Application EndPointUrl", endPointUrl);
+
+				return false;
+			}
+		}
+
 		// get element register interval url
 		dicoveryServerConfig->getConfigParameter("RegisterInterval", registerInterval_, "40000");
 


### PR DESCRIPTION
Closes #310

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] CHANGELOG have been updated

* **What kind of change does this PR introduce?**

Bug fix

* **What is the new behavior (if this is a feature change)?**

1.~~The server checks if DiscoveryServer URL conflict with Application EndpointURL and exits with a message in a log.~~
2. By default, endpoint is @HOSTNAME@
3. By default, DiscoveryServer configuration is switched off
