### PR TITLE
bugfix: update dependency of *-dev.deb

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -350,7 +350,7 @@ if (CPACK_BINARY_DEB)
         
     BoostDepends(libboost-test)
     set(DEB_DEPS_DEV "${DEB_DEPS_DEV}, ${LIST_OF_LIB_VERSIONS_DEV}")
-    set(DEB_DEPS_DEV "${DEB_DEPS_DEV}, OpcUaStack-${VERSION_MAJOR}-bin (=${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})")    
+    set(DEB_DEPS_DEV "${DEB_DEPS_DEV}, opcuastack-${VERSION_MAJOR}-bin (=${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})")    
     
     set(CPACK_DEBIAN_DEV_PACKAGE_DEPENDS ${DEB_DEPS_DEV})       
     set(CPACK_DEBIAN_BIN_PACKAGE_DEPENDS ${DEB_DEPS_BIN})             


### PR DESCRIPTION
The dependency was set set incorrectly causing apt-get to fail while installing the package

Closes #

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG have been updated (for bug fixes / features / docs)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
When installing the deb files using apt-get, we see the following error
```
The following packages have unmet dependencies:
{{ opcuastack-3-dev : Depends: OpcUaStack-3-bin (= 3.8.1) but it is not installable}}
E: Unable to correct problems, you have held broken packages. 
```

* **What is the new behavior (if this is a feature change)?**
The deb files can be installed using apt-get without any error.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
