### PR TITLE
Dequote DESTDIR to fix cmake error

### DIFF
--- a/src/OpcUaProjectBuilder/ProjectTemplate/build.bat
+++ b/src/OpcUaProjectBuilder/ProjectTemplate/build.bat
@@ -118,7 +118,7 @@ REM ---------------------------------------------------------------------------
 	REM install OpcUaStack
 	REM
     
-	set DESTDIR=%INSTALL_PREFIX%
+	set DESTDIR=%INSTALL_PREFIX:"=%
 	%CMAKE% --build build_local_%BUILD_DIR_SUFFIX% --target install --config %BUILD_TYPE%
 goto:eof
 


### PR DESCRIPTION
This commit dequotes DESTDIR to allow the following commands to succeed (from https://opcuastack.readthedocs.io/en/latest/1_getting_started/hello_world.html#building-and-running):

cd C:\Users\MyUsername\helloworld
build.bat -t local -i C:\Users\MyUsername\helloworld_install -s C:\ASNeG

Prior to this commit, the above build.bat command resulted in the following cmake error, related to improper path quoting:

  -- Install configuration: "Debug"
  CMake Error at cmake_install.cmake:45 (file):
    file cannot create directory: "C:/Users/MyUsername/helloworld_install"/usr/lib.
    Maybe need administrative privileges.

Closes #

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG have been updated (for bug fixes / features / docs)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
