### PR TITLE
Fix boost >1.70 compilaition

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@
 
 **Bugs**:
 
+* fix compiltation for boost 1.70 and higher #428, by @flipback
 * fix reconnect timer crash in session service #302, by @huebl
 * Add isNull and setNull function to class OpcUaNodeId #278, @huebl
 * Add Generator directory to cmake file #272, @huebl

--- a/docs/source/1_getting_started/installation.rst
+++ b/docs/source/1_getting_started/installation.rst
@@ -13,7 +13,7 @@ the following requirements:
 
 * Compiler with C++17 support (we test only GCC, Clang and Visual Studio)
 * CMake >= 3.5
-* Boost >= 1.58
+* Boost >= 1.65
 * OpenSSL >= 1.0.0
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -137,9 +137,9 @@ message(STATUS "  host system: ${CMAKE_HOST_SYSTEM}")
     set(Boost_USE_RELEASE_LIBS   ON)
  endif()
 add_definitions(-DBOOST_ALL_DYN_LINK)
+set(Boost_NO_BOOST_CMAKE ON)
 find_package(
     Boost 
-    "${BOOST_VERSION_MAJOR}.${BOOST_VERSION_MINOR}" 
     COMPONENTS program_options system unit_test_framework filesystem thread date_time chrono regex 
     REQUIRED
 )


### PR DESCRIPTION
Closes ASNeG/OpcUaStack#428

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG have been updated (for bug fixes / features / docs)

I used solution from [here](https://gitlab.kitware.com/cmake/cmake/-/issues/18865)
